### PR TITLE
language = en, split cicd.yml, localhost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+  push:
+
+jobs:
+
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2, with: {fetch-depth: 0}}
+      - {name: Install Python, uses: actions/setup-python@v2, with: {python-version: "3.10"}}
+      - {name: Install Poetry, uses: abatilo/actions-poetry@v2.1.4}
+      - {name: Install dependencies, run: make deps}
+      - {name: Run lints, run: make lint}
+      - {name: Run tests, run: make test}
+      - {name: Build docs, run: make docs}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration/Deploy
+name: Deploy
 
 on:
   push:
@@ -14,8 +14,6 @@ jobs:
       - {name: Install Python, uses: actions/setup-python@v2, with: {python-version: "3.10"}}
       - {name: Install Poetry, uses: abatilo/actions-poetry@v2.1.4}
       - {name: Install dependencies, run: make deps}
-      - {name: Run lints, run: make lint}
-      - {name: Run tests, run: make test}
       - name: Build docs
         env:
           SPHINX_HTML_BASEURL: "https://${{ github.event_name != 'release' && 'rob86stage.' || '' }}robpol86.com/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - Remove "documentation" from every `<title />`.
 - Generate a sitemap.xml file and reference it in a now-dynamic robots.txt file.
+- Setting baseline natural language to "en" for assistive technology.
 
 ## 2021-10-25
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,13 +25,14 @@ extensions = [
     "sphinxcontrib.youtube",  # https://github.com/sphinx-contrib/youtube
     "sphinxext.opengraph",  # https://sphinxext-opengraph.readthedocs.io
 ]
+language = "en"
 project = "Robpol86.com"
 pygments_style = "vs"
 templates_path = ["_templates"]
 
 
 # Options for HTML output.
-html_baseurl = os.environ.get("SPHINX_HTML_BASEURL", "http://127.0.0.1:8000/")
+html_baseurl = os.environ.get("SPHINX_HTML_BASEURL", "http://localhost:8000/")
 html_context = {
     "edit_page_url_template": (
         "{{ github_url }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}/{{ doc_path }}{{ file_name }}"
@@ -111,6 +112,10 @@ disqus_shortname = "rob86wiki"
 
 # https://sphinx-panels.readthedocs.io/en/latest/#sphinx-configuration
 panels_add_bootstrap_css = False
+
+
+# https://github.com/jdillard/sphinx-sitemap#customizing-the-url-scheme
+sitemap_url_scheme = "{link}"
 
 
 # https://github.com/Robpol86/sphinx-imgur


### PR DESCRIPTION
Split cicd.yml into ci.yml and deploy.yml. Allows ci.yml to support pull
requests.

Setting baseline natural language to "en" for assistive technology.

Using localhost instead of 127.0.0.1 since in some systems 127.0.0.2 may
be used instead.