### PR TITLE
Don't do diff on tag pushes.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -2,7 +2,7 @@ name: Diff against Production
 
 on:
   pull_request:
-  push:
+  push: {tags-ignore: ["**"]}
 
 jobs:
 

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -2,7 +2,7 @@ name: Diff against Production
 
 on:
   pull_request:
-  push: {tags-ignore: ["**"]}
+  push: {branches: ["**"]}
 
 jobs:
 


### PR DESCRIPTION
Usually tags are only for releases. Can't do a diff against prod because
the latest release is already created, but HTML files aren't yet built.
Also it would just be diffing against itself, pointless.