### PR TITLE
Handle poisoned cache.

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,4 +1,4 @@
-name: Publish to NFSN
+name: Deploy to NFSN
 description: Rsync HTML files to web host and purge Cloudflare cache
 
 inputs:

--- a/.github/actions/init-deps/action.yml
+++ b/.github/actions/init-deps/action.yml
@@ -23,8 +23,18 @@ runs:
       id: cache
       uses: actions/cache@v2
       with: {path: .venv, key: "${{ runner.os }}-venv-${{ hashFiles('poetry.lock') }}-${{ inputs.no-dev-deps }}"}
+    - name: Validate venv
+      id: validate
+      if: "steps.cache.outputs.cache-hit == 'true'"
+      shell: bash
+      run: |
+        poetry env info --ansi
+        if poetry env info --no-ansi |grep -qE "^Valid: +True"; then
+          echo "::set-output name=is-valid::true"
+        fi
+      # TODO: Evict cache on invalid venv: https://github.com/actions/cache/issues/2
     - name: Install dependencies
-      if: "steps.cache.outputs.cache-hit != 'true'"
+      if: "steps.validate.outputs.is-valid != 'true'"
       env: {NO_DEV: "${{ inputs.no-dev-deps == 'true' && 'true' || '' }}"}
       shell: bash
       run: make deps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - {name: Check out repository code, uses: actions/checkout@v2}
       - {name: Fetch HTML files, uses: actions/download-artifact@v2, with: {name: html, path: build/html/}}
       - name: Deploy
-        uses: ./.github/actions/publish
+        uses: ./.github/actions/deploy
         with:
           source: build/html/
           user: "${{ github.event_name == 'release' && secrets.NFSN_SSH_USER_PROD || secrets.NFSN_SSH_USER_STAGE }}"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ poetry.lock:
 deps: _HELP = Install project dependencies (optional NO_DEV env var)
 deps:
 	poetry install $(if $(NO_DEV),--no-dev)
+	poetry env info --ansi
+	poetry env info --no-ansi |grep -qE "^Valid: +True"
 	poetry run python -V
 
 ## Testing


### PR DESCRIPTION
Every now and then the cached venv in GitHub Actions gets broken
according to poetry. Haven't figured out why yet.
Since there's no way to evict cache yet in actions/cache the best
mitigation is to just re-install when a broken venv is detected.