### PR TITLE
Create pre-releases on PR merges.

### DIFF
--- a/.github/actions/read-changelog/action.yml
+++ b/.github/actions/read-changelog/action.yml
@@ -1,0 +1,108 @@
+name: Read Changelog
+description: Read certain data from changelog.
+
+inputs:
+  section:
+    description: Section to search for
+    required: true
+  has_title:
+    description: If the section has a one-line title
+    required: false
+    default: "true"
+  path:
+    description: Path to CHANGELOG.md
+    required: false
+    default: "${{ github.workspace }}/CHANGELOG.md"
+
+runs:
+  using: composite
+  steps:
+    - name: Find section
+      id: find
+      env:
+        CL_FILE: "${{ inputs.path }}"
+        SECTION: "${{ inputs.section }}"
+      shell: bash
+      run: |
+        test -f "$CL_FILE" || { echo "ERROR: Not a file: $_" >&2; exit 1; }
+        test -n "$SECTION" || { echo "ERROR: No section specified" >&2; exit 1; }
+        awk -v section="$SECTION" '
+          function error(msg) { if (!e) { printf("ERROR: %s\n", msg) > "/dev/stderr"; e=1 }; exit 1 }
+
+          # Find section.
+          match($0, /^## (.+)$/, m) && section == m[1] { found=1; exit }
+
+          END {
+            if (!found) error("Section not found")
+            printf("::set-output name=start::%d\n", NR + 1)
+          }
+        ' "$CL_FILE"
+
+    - name: Get title
+      id: title
+      if: "${{ inputs.has_title == 'true' }}"
+      env:
+        CL_FILE: "${{ inputs.path }}"
+        START: "${{ steps.find.outputs.start }}"
+      shell: bash
+      run: |
+        awk -v start="$START" '
+          function error(msg) { if (!e) { printf("ERROR: %s\n", msg) > "/dev/stderr"; e=1 }; exit 1 }
+
+          # Go to starting line.
+          NR < start { next }
+
+          # Next non-empty line will be title.
+          /.+/ { title=$0; exit }
+
+          END {
+            if (!title) error("Title not found")
+            if (title !~ /^[A-Za-z0-9]/) error(sprintf("Invalid title for section: %s", title))
+            printf("::set-output name=title::%s\n", $title)
+            printf("::set-output name=start::%d\n", NR + 1)
+          }
+        ' "$CL_FILE"
+
+    - name: Get body
+      id: body
+      env:
+        CL_FILE: "${{ inputs.path }}"
+        START: "${{ inputs.has_title == 'true' && steps.title.outputs.start || steps.find.outputs.start }}"
+      shell: bash
+      run: |
+        body_file="$(mktemp)"
+
+        # Read body into temporary file.
+        awk -v start="$START" -v body_file="$body_file" '
+          # Go to starting line.
+          NR < start { next }
+
+          # Go to first non-empty line.
+          !found && !/.+/ { next }
+          !found { found=1 }
+
+          # Read body until next section.
+          found && !/^##? / { print >> body_file; next }
+          found { exit }
+        ' "$CL_FILE"
+
+        # Delete all trailing blank lines at end of file.
+        sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$body_file"
+
+        # Print after escaping: https://github.community/t/set-output-truncates-multiline-strings/16852/5
+        awk '
+          BEGIN { printf("::set-output name=body::") }
+                { gsub(/%/, "%25"); printf("%s%%0A", $0) }
+          END   { printf("\n") }
+        ' "$body_file"
+
+        # Cleanup.
+        rm -f "$body_file"
+
+outputs:
+  title:
+    description: Section title
+    value: ${{ steps.title.outputs.title }}
+  body:
+    description: Section title
+    value: ${{ steps.body.outputs.body }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -29,3 +29,30 @@ jobs:
           user: "${{ secrets.NFSN_SSH_USER_STAGE }}"
           ssh-key: "${{ secrets.NFSN_SSH_KEY }}"
           cf-token: "${{ secrets.TOKEN_CF_PURGE_CACHE }}"
+
+  pre-release:
+    name: Create Pre-release
+    runs-on: ubuntu-latest
+    needs: publish
+    if: "github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, ' (#')"
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Fetch HTML files, uses: actions/download-artifact@v2, with: {name: html, path: build/html/}}
+      - {name: Archive HTML files, run: tar -C build -czvf html.tar.gz html/}
+      - {name: Get body, id: cl, uses: ./.github/actions/read-changelog, with: {section: "[Unreleased]", has_title: "false"}}
+      - name: Get title
+        id: commit
+        run: "head -1 <<< '${{ github.event.commits[0].message }}' |xargs -0 printf '::set-output name=title::%s'"
+      - name: Delete existing pre-release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with: {delete_release: true, tag_name: pre-release}
+        env: {GITHUB_TOKEN: "${{ github.token }}"}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "${{ steps.commit.outputs.title }}"
+          body: "${{ steps.cl.outputs.body }}"
+          tag_name: pre-release
+          prerelease: true
+          target_commitish: "${{ github.ref }}"
+          files: html.tar.gz

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -45,14 +45,14 @@ jobs:
         run: "head -1 <<< '${{ github.event.commits[0].message }}' |xargs -0 printf '::set-output name=title::%s'"
       - name: Delete existing pre-release
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
-        with: {delete_release: true, tag_name: pre-release}
+        with: {delete_release: true, tag_name: _pre-release}
         env: {GITHUB_TOKEN: "${{ github.token }}"}
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
           name: "${{ steps.commit.outputs.title }}"
           body: "${{ steps.cl.outputs.body }}"
-          tag_name: pre-release
+          tag_name: _pre-release
           prerelease: true
           target_commitish: "${{ github.ref }}"
           files: html.tar.gz


### PR DESCRIPTION
To be used by new diff.yml GitHub Action on the way. Using pre-releases
to store HTML files that can be diffed in PRs. Currently diff is against
prod, which gets ugly when merges to main branch aren't immediately
published.

Pre-release titles will be the same as the merged PR's title and bodies
are the current "Unreleased" section in the changelog file.