### PR TITLE
Refactor diffing. Diff against PR merges only.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -2,57 +2,86 @@ name: Diff
 
 on:
   pull_request:
-  push: {branches: ["**"]}
 
 jobs:
-
-  query:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Query GitHub API for latest release
-        run: "curl -o latest.json https://api.github.com/repos/${{ github.repository }}/releases/latest"
-      - name: Validate
-        run: jq -r '.tag_name // error' < latest.json |grep .
-      - name: Set tag name
-        run: jq -r '"::set-output name=tag_name::" + .tag_name' < latest.json
-        id: tag_name
-    outputs:
-      tag_name: ${{ steps.tag_name.outputs.tag_name }}
 
   build:
     name: Build HTML
     runs-on: ubuntu-latest
-    needs: query
-    env:
-      SPHINX_GITHUB_BRANCH: "${{ needs.query.outputs.tag_name }}"
-      SPHINX_HTML_BASEURL: "https://robpol86.com/"
     steps:
       - {name: Check out repository code, uses: actions/checkout@v2, with: {fetch-depth: 0}}
       - {name: Initialize dependencies, uses: ./.github/actions/init-deps}
-      - {name: Build docs, run: make docs}
-      - {name: Prettify, uses: ./.github/actions/prettify, with: {path: html}}
+      - {name: Build docs, run: make docs, env: {SPHINX_HTML_BASEURL: "https://rob86stage.robpol86.com/", SPHINX_GITHUB_BRANCH: main}}
+      - {name: Prettify, uses: ./.github/actions/prettify, with: {path: build/html}}
       - name: Store HTML
         uses: actions/upload-artifact@v2
         with: {name: html_feature, path: build/html/, if-no-files-found: error}
 
   fetch:
+    name: Fetch Pre-Release HTML
     runs-on: ubuntu-latest
-    needs: query
     steps:
       - {name: Check out repository code, uses: actions/checkout@v2}
-      - name: Download release artifact
-        env: {REPO: "${{ github.repository }}", TAG: "${{ needs.query.outputs.tag_name }}"}
-        run: "curl -L https://github.com/${{ env.REPO }}/releases/download/${{ env.TAG }}/html.tar.gz |tar -xzv"
-      - {name: Prettify, uses: ./.github/actions/prettify, with: {path: html}}
+      - name: Download pre-release artifact
+        env: {URL: "https://github.com/${{ github.repository }}/releases/download/_pre-release/html.tar.gz"}
+        run: |
+          mkdir build
+          until wget "$URL" -O html.tar.gz; do sleep 5; done
+          tar -C build -xzvf html.tar.gz
+        timeout-minutes: 1
+      - name: Prettify
+        uses: ./.github/actions/prettify
+        with: {path: build/html}
       - name: Store HTML
         uses: actions/upload-artifact@v2
-        with: {name: html_prod, path: html/, if-no-files-found: error}
+        with: {name: html_pre, path: build/html/, if-no-files-found: error}
 
   diff:
+    name: Diff
     runs-on: ubuntu-latest
     needs: [fetch, build]
     steps:
       - {name: Fetch this feature build, uses: actions/download-artifact@v2, with: {name: html_feature, path: html_feature}}
-      - {name: Fetch latest release, uses: actions/download-artifact@v2, with: {name: html_prod, path: html_prod}}
+      - {name: Fetch latest pre-release, uses: actions/download-artifact@v2, with: {name: html_pre, path: html_pre}}
       - {name: Clean, run: "find . '(' -name __pycache__ -o -name .doctrees ')' -type d -exec rm -rv {} +"}
-      - {name: Diff, run: "diff --color=always --recursive html_prod/ html_feature/ || true"}
+      - name: Diff
+        id: diff
+        run: |
+          diff --color=always --recursive html_pre/ html_feature/ || true
+          diff --color=never --recursive html_pre/ html_feature/ > all.diff || true
+          if [ -s all.diff ]; then
+            echo "::set-output name=nonzero::true"
+            cp all{,-orig}.diff
+            head -c 261445 all-orig.diff > all.diff
+            if ! cmp -s all{,-orig}.diff; then
+              echo -e "\n\nTruncated" >> all.diff
+            fi
+          fi
+      - name: Post diff to PR if any changes are detected
+        uses: actions/github-script@v5
+        env: {DIFF_NONZERO: "${{ steps.diff.outputs.nonzero }}"}
+        with:
+          script: |
+            const heading = 'Diff Against [Pre-Release](https://github.com/Robpol86/robpol86.com/releases/tag/_pre-release)'
+            var body
+
+            if (!process.env.DIFF_NONZERO) {
+              body = '*No HTML changes detected.*'
+            } else {
+              const {promises: fs} = require('fs')
+              const diff = (await fs.readFile('all.diff', 'utf8')).trim()
+              body = '```diff\n' + diff + '\n```\n'
+
+              // If diff is large collapse it to reduce clutter in the PR.
+              let numLines = diff.match(/^/mg).length
+              if (numLines > 10) {
+                body = '<details>\n<summary>Show ' + numLines + ' lines</summary>\n\n' + body + '\n</details>'
+              }
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '### ' + heading + '\n\n' + body
+            })


### PR DESCRIPTION
Fix issue where diffing against prod includes other merged changes not
yet published. Made diffing worthless. Now diffing is against last
merged PR, and it's also posted as a comment to the PR to surface it
better.

Diffing only on pull requests. Doing it for every branch push is too
expensive and I never look at diffs until right before merging to main
anyway.