### PR TITLE
Adding placeholder blog post.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - Latest version of sphinx-book-theme with performance enhancements.
 - Implemented support for tagging documents using a slightly customized Sphinx `index` directive.
-- Using sphinx_external_toc to support blog posts.
+- Using sphinx_external_toc to support future blog posts.
 
 ## 2022-01-28
 

--- a/docs/.toc.yml
+++ b/docs/.toc.yml
@@ -20,6 +20,11 @@ subtrees:
       - file: flash_droid_cricket
       - file: rns_510_vim
       - file: imagecfg
+#  - caption: Posts
+#    maxdepth: 1
+#    reversed: True
+#    entries:
+#      - glob: posts/[0-9][0-9][0-9][0-9]/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*
   - caption: Archived Projects
     maxdepth: 2
     entries:

--- a/docs/posts/2022/2022-03-30-placeholder-post.md
+++ b/docs/posts/2022/2022-03-30-placeholder-post.md
@@ -1,0 +1,6 @@
+:orphan:
+:nosearch:
+
+# Placeholder Post
+
+This is a placeholder and will be removed when I have content for a real post.


### PR DESCRIPTION
I don't have content for a blog post yet but I don't want to forget how
to make posts using Sphinx. So for now I'm adding a hidden blog post
that serves as a placeholder. It still shows up on the sitemap but not
on the front page or any sidebar.

To make a blog post uncomment the stanza in .toc.yml and remove the
field list items at the top of the md file.