### PR TITLE
background: unset; tag formatting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     # Staging
     branches: ["**"]
     # Production
-    tags: ["[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"]
+    tags: ["[0-9][0-9][0-9][0-9].[0-9][0-9]?.[0-9][0-9]?"]
 
 env:
   BASEURL_PROD: https://robpol86.com/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
-- N/A
+- Use `background: unset` instead of repeating background image.
+- Change tag formatting to match changelog version formatting.
+- Refactor deploy. (#153)
+- Style: explode yml (#151)
+- Combining stage/prod workflows. (#150)
+- Setting to a real version. (#147)
+- Boilerplate, output directory, reorg tests. (#146)
+- Disabling GitHub page link locally. (#145)
+- Adding robpol86_com package. (#144)
+- Restyle conf.py. (#142)
+- Drop unused MyST extensions. (#141)
+- Dropping Python 3.7 support. (#139)
+- Removing sphinx-panels. (#138)
+- Latest myst-parser. (#132)
+- Refactor HTML Diff in PRs. (#136)
+- Style changes from other repos. (#129)
 
 ## [2022.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,14 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+- Updated repo boilerplate to match sphinx-carousel.
+- Refactored and restyled deploy and HTML diff workflows.
+- Using real versions similar to semver but date-based.
+- Moving code from `conf.py` into `robpol86_com` package.
+- Disabling GitHub page link when building locally, no more faking.
+- Latest myst-parser.
+- Dropping Python 3.7 support after updating Python in desktop WSL.
 - Use `background: unset` instead of repeating background image.
-- Change tag formatting to match changelog version formatting.
-- Refactor deploy. (#153)
-- Style: explode yml (#151)
-- Combining stage/prod workflows. (#150)
-- Setting to a real version. (#147)
-- Boilerplate, output directory, reorg tests. (#146)
-- Disabling GitHub page link locally. (#145)
-- Adding robpol86_com package. (#144)
-- Restyle conf.py. (#142)
-- Drop unused MyST extensions. (#141)
-- Dropping Python 3.7 support. (#139)
-- Removing sphinx-panels. (#138)
-- Latest myst-parser. (#132)
-- Refactor HTML Diff in PRs. (#136)
-- Style changes from other repos. (#129)
 
 ## [2022.4.1]
 

--- a/docs/_static/background_image.css
+++ b/docs/_static/background_image.css
@@ -11,12 +11,12 @@ body {
 }
 
 .bd-toc nav {
-    background-image: url("setup.jpg");
+    background: unset;
 }
 
 @media (min-width: 720px) {
     /* Make the left column transparent except on mobile where the column slides over the main content. */
     #site-navigation {
-        background-image: url("setup.jpg");
+        background: unset;
     }
 }


### PR DESCRIPTION
Use `background: unset` instead of repeating background image. Reduces
repeating pattern, instead making divs transparent.

Change tag formatting to match changelog version formatting.