### PR TITLE
parse_extra_navbar()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - Using real versions similar to semver but date-based.
 - Latest book theme.
 - Removing download and fullscreen buttons.
+- Templatizing `html_theme_options["extra_navbar"]`.
 
 ## [2022.4.1]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ html_context = {
     "edit_page_url_template": (
         "{{ github_url }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}/{{ doc_path }}{{ file_name }}"
     ),
+    "license": __license__,
 }
 html_copy_source = False
 html_css_files = ["background_image.css", "fixes.css"]
@@ -74,11 +75,14 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "extra_navbar": (
         "<p>"
-        '<a href="/genindex.html">Tags</a> | <a href="/sitemap.xml">Sitemap</a><br>'
+        '<a href="{{ pathto("genindex") }}">Tags</a> | '
+        '<a href="{{ pathto("sitemap")|replace(".html", ".xml") }}">Sitemap</a><br>'
         'Generator: <a href="https://www.sphinx-doc.org/">Sphinx</a><br>'
         'Theme: <a href="https://sphinx-book-theme.readthedocs.io/">Sphinx Book Theme</a><br>'
         'Host: <a href="https://www.nearlyfreespeech.net/">NearlyFreeSpeech.NET</a><br>'
-        f'License: <a href="{GIT_URL}/blob/{GIT_BRANCH}/LICENSE">{__license__}</a><br>'
+        "{% if theme_repository_url %}"
+        'License: <a href="{{ theme_repository_url }}/blob/{{ theme_repository_branch }}/LICENSE">{{ license }}</a><br>'
+        "{% endif %}"
         "</p>"
     ),
     "logo_only": True,

--- a/robpol86_com/html_context.py
+++ b/robpol86_com/html_context.py
@@ -22,9 +22,24 @@ def change_icon_tooltip(_, __, ___, context: Dict, ____):
             button["tooltip"] = "View page source"
 
 
+def parse_extra_navbar(app: Sphinx, __, ___, context: Dict, ____):
+    """Parse Jinja2 in extra_navbar theme option.
+
+    :param app: Sphinx application object.
+    :param __: Unused.
+    :param ___: Unused.
+    :param context: HTML context.
+    :param ____: Unused.
+    """
+    theme_extra_navbar: str = context.get("theme_extra_navbar", "")
+    if theme_extra_navbar:
+        context["theme_extra_navbar"] = app.builder.templates.render_string(theme_extra_navbar, context)
+
+
 def setup(app: Sphinx):
     """Called by Sphinx.
 
     :param app: Sphinx application object.
     """
     app.connect("html-page-context", change_icon_tooltip, priority=999)
+    app.connect("html-page-context", parse_extra_navbar)


### PR DESCRIPTION
Templatizing html_theme_options.extra_navbar.

Making genindex and sitemap relative instead of hard-coding to `/`,
which doesn't work locally.

Fixes https://github.com/Robpol86/robpol86.com/issues/156