### PR TITLE
Reducing complexity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,6 @@ jobs:
           SPHINX_GITHUB_BRANCH: "${{ inputs.sphinx_github_branch }}"
           SPHINX_HTML_BASEURL: "${{ inputs.sphinx_html_baseurl }}"
         run: |
-          if [ -z "${SPHINX_GITHUB_BRANCH:-}" ]; then unset SPHINX_GITHUB_BRANCH; fi
-          if [ -z "${SPHINX_HTML_BASEURL:-}" ]; then unset SPHINX_HTML_BASEURL; fi
           make docs && cp -v .gitignore docs/_build/html/
 
       - name: Prettify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 
+
 on:
   push:
     # Staging
@@ -7,16 +8,17 @@ on:
     # Production
     tags: ["[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"]
 
+
 env:
   BASEURL_PROD: https://robpol86.com/
   BASEURL_STAGE: https://rob86stage.robpol86.com/
   HTML_ROOT: ./docs/_build/html
   IS_PROD: "${{ startsWith(github.ref, 'refs/tags/') && 'true' || '' }}"
 
+
 jobs:
 
-  build:
-    name: Build HTML
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,13 +31,13 @@ jobs:
         env:
           SPHINX_HTML_BASEURL: "${{ env.IS_PROD && env.BASEURL_PROD || env.BASEURL_STAGE }}"
         run: make docs
-      - name: Store HTML as temporary artifact
+      - name: Store HTML as Temporary Artifact
         uses: actions/upload-artifact@v3
         with:
           name: html
           path: "${{ env.HTML_ROOT }}"
           if-no-files-found: error
-      - name: Get version
+      - name: Get Version
         id: version
         env:
           AWK_PROGRAM: |
@@ -46,8 +48,9 @@ jobs:
               exit
             }
             END { exit !flag }
-        run: ${{ env.IS_PROD && 'printenv GITHUB_REF_NAME' || 'poetry version' }} |awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM"
-      - name: Find version in changelog
+        run: |
+          ${{ env.IS_PROD && 'printenv GITHUB_REF_NAME' || 'poetry version' }} |awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM"
+      - name: Find Version in Changelog
         id: section_start
         env:
           AWK_PROGRAM: |
@@ -66,7 +69,7 @@ jobs:
               if (!found) error("No section found")
             }
         run: awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM" CHANGELOG.md
-      - name: Get title from changelog
+      - name: Get Title from Changelog
         id: title
         env:
           AWK_PROGRAM: |
@@ -88,7 +91,7 @@ jobs:
               if (!found) error("No title found")
             }
         run: awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM" CHANGELOG.md
-      - name: Get description from changelog if available
+      - name: Get Description from Changelog if Available
         id: description
         env:
           AWK_PROGRAM: |
@@ -137,10 +140,9 @@ jobs:
       CL_TITLE: "${{ steps.title.outputs.TITLE }}"
       CL_DESCRIPTION: "${{ steps.description.outputs.DESCRIPTION }}"
 
-  publish:
-    name: Publish to NFSN
+  Publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: Build
     concurrency: "${{ github.workflow }}-${{ github.job }}"
     steps:
       - name: Fetch HTML files
@@ -164,24 +166,23 @@ jobs:
           CF_URL: "https://api.cloudflare.com/client/v4/zones/5efb26a03250a8bc392727af05a39aba/purge_cache"
         run: curl -f "$CF_URL" -H "$CF_AUTH" --data '{"purge_everything":true}'
 
-  release:
-    name: Create Release
+  Release:  # TODO remove, switch to workflow_dispatch
     if: startsWith(github.ref, 'refs/tags/')  # env.IS_PROD
     runs-on: ubuntu-latest
-    needs: [build, publish]
+    needs: [Build, Publish]
     steps:
-      - name: Fetch HTML files
+      - name: Fetch HTML Files
         uses: actions/download-artifact@v3
         with:
           name: html
           path: html
-      - name: Archive HTML files
+      - name: Archive HTML Files
         run: tar -czvf html.tar.gz html/
       - name: Create release
         uses: softprops/action-gh-release@v1
         env:
-          NAME: "${{ needs.build.outputs.CL_TITLE }}"
-          BODY: "${{ needs.build.outputs.CL_DESCRIPTION }}"
+          NAME: "${{ needs.Build.outputs.CL_TITLE }}"
+          BODY: "${{ needs.Build.outputs.CL_DESCRIPTION }}"
         with:
           name: "${{ env.NAME }}"
           body: "${{ env.BODY }}"

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -21,14 +21,26 @@ env:
 
 jobs:
 
+  LoadEnvironment:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Retrieve Variables
+        id: vars
+        env:
+          SPHINX_HTML_BASEURL: ${{ vars.SPHINX_HTML_BASEURL }}
+        run: echo "SPHINX_HTML_BASEURL=$SPHINX_HTML_BASEURL" >> "$GITHUB_OUTPUT"
+    outputs:
+      SPHINX_HTML_BASEURL: "${{ steps.vars.outputs.SPHINX_HTML_BASEURL }}"
+
   Build:
+    needs: LoadEnvironment
     uses: ./.github/workflows/build.yml
     with:
       prettyfy: true
       skip_lints_tests: true
       sphinx_github_branch: main
-      sphinx_html_baseurl: ${{ vars.SPHINX_HTML_BASEURL }}
-    environment: staging
+      sphinx_html_baseurl: ${{ needs.LoadEnvironment.outputs.SPHINX_HTML_BASEURL }}
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -27,7 +27,7 @@ jobs:
       prettyfy: true
       skip_lints_tests: true
       sphinx_github_branch: main
-      sphinx_html_baseurl: https://rob86stage.robpol86.com/
+      sphinx_html_baseurl: https://rob86stage.robpol86.com/  # TODO use GitHub Environments variables
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -21,26 +21,13 @@ env:
 
 jobs:
 
-  LoadEnvironment:
-    runs-on: ubuntu-latest
-    environment: staging
-    steps:
-      - name: Retrieve Variables
-        id: vars
-        env:
-          SPHINX_HTML_BASEURL: ${{ vars.SPHINX_HTML_BASEURL }}
-        run: echo "SPHINX_HTML_BASEURL=$SPHINX_HTML_BASEURL" >> "$GITHUB_OUTPUT"
-    outputs:
-      SPHINX_HTML_BASEURL: "${{ steps.vars.outputs.SPHINX_HTML_BASEURL }}"
-
   Build:
-    needs: LoadEnvironment
     uses: ./.github/workflows/build.yml
     with:
       prettyfy: true
       skip_lints_tests: true
       sphinx_github_branch: main
-      sphinx_html_baseurl: ${{ needs.LoadEnvironment.outputs.SPHINX_HTML_BASEURL }}
+      sphinx_html_baseurl: "http://diff.local:1234/"
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       prettyfy: true
       skip_lints_tests: true
-      sphinx_github_branch: main  # TODO "${{ env.BRANCH_NAME_HTML_OLD }}"
+      sphinx_github_branch: __diff__html_old
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -17,7 +17,6 @@ env:
   DIFF_CONTEXT: 5
   DIFF_TRUNCATE_TO_BYTES: 256000
   POST_COLLAPSE_GT_LINES: 10
-  ROOT_DIR_DIFF: ./docs/_build/html
 
 
 jobs:

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -26,8 +26,7 @@ jobs:
     with:
       prettyfy: true
       skip_lints_tests: true
-      sphinx_github_branch: main
-      sphinx_html_baseurl: "http://diff.local:1234/"
+      sphinx_github_branch: main  # TODO "${{ env.BRANCH_NAME_HTML_OLD }}"
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -22,13 +22,13 @@ env:
 jobs:
 
   Build:
-    environment: staging
     uses: ./.github/workflows/build.yml
     with:
       prettyfy: true
       skip_lints_tests: true
       sphinx_github_branch: main
-      sphinx_html_baseurl: https://rob86stage.robpol86.com/  # TODO use GitHub Environments variables
+      sphinx_html_baseurl: ${{ vars.SPHINX_HTML_BASEURL }}
+    environment: staging
 
   Commit:
     if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -22,6 +22,7 @@ env:
 jobs:
 
   Build:
+    environment: staging
     uses: ./.github/workflows/build.yml
     with:
       prettyfy: true

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Robpol86.com
 
 [![Github-CI][github-ci]][github-link]
-[![Code style: black][black-badge]][black-link]
 
-[github-ci]: https://github.com/Robpol86/sphinx-carousel/actions/workflows/ci.yml/badge.svg?branch=main
-[github-link]: https://github.com/Robpol86/sphinx-carousel/actions/workflows/ci.yml
-[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
-[black-link]: https://github.com/ambv/black
+[github-ci]: https://github.com/Robpol86/robpol86.com/actions/workflows/build.yml/badge.svg?branch=main
+[github-link]: https://github.com/Robpol86/robpol86.com/actions/workflows/build.yml
 
 My personal website.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from robpol86_com import __license__, __version__ as version
 
 GIT_BRANCH = os.environ.get("SPHINX_GITHUB_BRANCH", "") or os.environ.get("GITHUB_REF", "").split("/", 2)[-1] or None
-GIT_URL = f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}' if "GITHUB_REPOSITORY" in os.environ else None
+GIT_URL = f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}' if os.environ.get("GITHUB_REPOSITORY", "") else None
 
 
 # General configuration.
@@ -39,7 +39,7 @@ templates_path = ["_templates"]
 
 
 # Options for HTML output.
-html_baseurl = os.environ.get("SPHINX_HTML_BASEURL", "http://localhost:8000/")
+html_baseurl = os.environ.get("SPHINX_HTML_BASEURL", "") or "http://localhost:8000/"
 html_context = {
     "edit_page_url_template": (
         "{{ github_url }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}/{{ doc_path }}{{ file_name }}"


### PR DESCRIPTION
No need to unset empty variables anymore, I was using `os.environ.get("x", "default")` instead of `or` in conf.py.

Style changes for consistency.

Using the dev default for baseurl in diffs. Eliminates need for GitHub Environments which don't work very well with reusable workflows. Also using the same branch name as the diff orphan branch for source paths in the HTML, even tho `env` context isn't available when calling reusable workflows. Maybe one day in the future GitHub will enable the context. Hard-coding twice for now.

Fixing links in the project README file. They were broken since last year, oops.