### PR TITLE
Refactoring Deploy (Staging Only)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 
 on:
-  pull_request:
   push:
   workflow_call:
     inputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   push:
   workflow_call:
     inputs:
+      environment:
+        required: false
+        type: string
       prettyfy:
         required: false
         type: boolean
@@ -15,15 +18,13 @@ on:
       sphinx_github_branch:  # For HTML diff
         required: false
         type: string
-      sphinx_html_baseurl:
-        required: false
-        type: string
 
 
 jobs:
 
   Build:
     runs-on: ubuntu-latest
+    environment: "${{ inputs.environment }}"  # Note: can be empty
     steps:
 
       - name: Checkout
@@ -49,9 +50,9 @@ jobs:
         run: make it
 
       - name: Build
-        env:
+        env:  # Note: these can be empty
           SPHINX_GITHUB_BRANCH: "${{ inputs.sphinx_github_branch }}"
-          SPHINX_HTML_BASEURL: "${{ inputs.sphinx_html_baseurl }}"
+          SPHINX_HTML_BASEURL: "${{ vars.SPHINX_HTML_BASEURL }}"
         run: |
           make docs && cp -v .gitignore docs/_build/html/
 

--- a/.github/workflows/deploy.awk
+++ b/.github/workflows/deploy.awk
@@ -1,9 +1,0 @@
-function error(msg) {
-  print(msg) > "/dev/stderr"
-  exit 1
-}
-
-function setOutput(name, value) {
-  printf("Set Output: %s=%s\n", name, value)
-  printf("%s=%s\n", name, value) >> GITHUB_OUTPUT
-}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
   Build:
     uses: ./.github/workflows/build.yml
     with:
+      environment: staging  # TODO staging/production
       skip_lints_tests: true
 
   Deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,150 +2,25 @@ name: Deploy
 
 
 on:
-  push:
-    # Staging
-    branches: ["**"]
-    # Production
-    tags: ["[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"]
-
-
-env:
-  BASEURL_PROD: https://robpol86.com/
-  BASEURL_STAGE: https://rob86stage.robpol86.com/
-  HTML_ROOT: ./docs/_build/html
-  IS_PROD: "${{ startsWith(github.ref, 'refs/tags/') && 'true' || '' }}"
+  pull_request:
 
 
 jobs:
 
   Build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Setup Dependencies
-        uses: ./.github/actions/deps
-      - name: Build docs
-        env:
-          SPHINX_HTML_BASEURL: "${{ env.IS_PROD && env.BASEURL_PROD || env.BASEURL_STAGE }}"
-        run: make docs
-      - name: Store HTML as Temporary Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: html
-          path: "${{ env.HTML_ROOT }}"
-          if-no-files-found: error
-      - name: Get Version
-        id: version
-        env:
-          AWK_PROGRAM: |
-            @include ".github/workflows/deploy.awk"
-            match($0, /([0-9]{4})[^0-9]([0-9]{1,2})[^0-9]([0-9]{1,2})[[:space:]]*$/, ymd) {
-              setOutput("VERSION", sprintf("%d.%d.%d", ymd[1], ymd[2], ymd[3]))
-              flag = 1
-              exit
-            }
-            END { exit !flag }
-        run: |
-          ${{ env.IS_PROD && 'printenv GITHUB_REF_NAME' || 'poetry version' }} |awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM"
-      - name: Find Version in Changelog
-        id: section_start
-        env:
-          AWK_PROGRAM: |
-            @include ".github/workflows/deploy.awk"
-            BEGIN {
-              version = "${{ steps.version.outputs.VERSION }}"  # e.g. 2022.4.1
-            }
-            /^## \[[0-9]/ {
-              found = 1
-              if (!match($0, /^## \[([0-9]{4}[.][0-9]{1,2}[.][0-9]{1,2})]$/, a)) error("First section invalid format")
-              if (a[1] != version) error("First section doesnt match version " version)
-              setOutput("NR", NR+1)
-              exit 0
-            }
-            END {
-              if (!found) error("No section found")
-            }
-        run: awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM" CHANGELOG.md
-      - name: Get Title from Changelog
-        id: title
-        env:
-          AWK_PROGRAM: |
-            @include ".github/workflows/deploy.awk"
-            BEGIN {
-              nr = int("${{ steps.section_start.outputs.NR }}")
-            }
-            NR < nr {
-              next
-            }
-            /^.+/ {
-              found = 1
-              if (!match($0, /^[A-Z]/)) error("Invalid title: " $0)
-              setOutput("TITLE", $0)
-              setOutput("NR", NR+1)
-              exit 0
-            }
-            END {
-              if (!found) error("No title found")
-            }
-        run: awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM" CHANGELOG.md
-      - name: Get Description from Changelog if Available
-        id: description
-        env:
-          AWK_PROGRAM: |
-            @include ".github/workflows/deploy.awk"
-            BEGIN {
-              nr = int("${{ steps.title.outputs.NR }}")
-            }
-            NR < nr {
-              next
-            }
-            /^## / {
-              exit 0
-            }
-            /^$/ && !found {
-              next  # Skip empty lines after title.
-            }
-            /^.+/ {
-              found = 1
-            }
-            found {
-              lines[linesLen++] = $0
-            }
-            END {
-              # Drop trailing empty lines.
-              while (length(lines) && length(lines[length(lines)-1]) == 0) {
-                delete lines[length(lines)-1]
-              }
-              if (!length(lines)) {
-                print("No description available")
-                exit 0
-              }
-              # Join array.
-              for (idx in lines) {
-                # https://github.community/t/set-output-truncates-multiline-strings/16852/2
-                line = gensub(/%/, "%25", "g", lines[idx])
-                if (idx == 0)
-                  description = line
-                else
-                  description = description "%0D" line
-              }
-              # Print.
-              setOutput("DESCRIPTION", description)
-            }
-        run: awk -v "GITHUB_OUTPUT=$GITHUB_OUTPUT" "$AWK_PROGRAM" CHANGELOG.md
-    outputs:
-      CL_TITLE: "${{ steps.title.outputs.TITLE }}"
-      CL_DESCRIPTION: "${{ steps.description.outputs.DESCRIPTION }}"
+    uses: ./.github/workflows/build.yml
+    with:
+      skip_lints_tests: true
 
-  Publish:
+  Deploy:
     runs-on: ubuntu-latest
+    environment: staging  # TODO staging/production
     needs: Build
-    concurrency: "${{ github.workflow }}-${{ github.job }}"
+    concurrency:
+      cancel-in-progress: true
+      group: "deploy-staging"  # TODO staging/production
     steps:
-      - name: Fetch HTML files
+      - name: Download HTML
         uses: actions/download-artifact@v3
         with:
           name: html
@@ -153,37 +28,15 @@ jobs:
       - name: Setup SSH
         uses: shimataro/ssh-key-action@v2
         with:
-          key: "${{ secrets.NFSN_SSH_KEY }}"
-          known_hosts: >
-            |1|DPaY4V21SA8hqGGhvfofQD+4Q9s=|AxxSLwKe688+1aemg21SbQL4MxU= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICbXE1f5S3N/flFHUm2i97tzKGJUWzxotY1HHBMIX72h
+          key: "${{ secrets.SSH_PRIVATE_KEY }}"
+          known_hosts: "${{ vars.SSH_KNOWN_HOSTS }}"
       - name: Rsync
         env:
-          SSH_USER: "${{ env.IS_PROD && secrets.NFSN_SSH_USER_PROD || secrets.NFSN_SSH_USER_STAGE }}"
-        run: rsync -rptcivh --delete-after --stats ./html/ "$SSH_USER@ssh.nyc1.nearlyfreespeech.net:/home/public"
+          SSH_HOST: "${{ vars.SSH_HOST }}"
+          SSH_USER: "${{ secrets.SSH_USER }}"
+        run: rsync -rptcivh --delete-after --stats ./html/ "$SSH_USER@$SSH_HOST:/home/public"
       - name: Purge Cloudflare Cache
         env:
-          CF_AUTH: "Authorization: Bearer ${{ secrets.TOKEN_CF_PURGE_CACHE }}"
-          CF_URL: "https://api.cloudflare.com/client/v4/zones/5efb26a03250a8bc392727af05a39aba/purge_cache"
+          CF_AUTH: "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}"
+          CF_URL: "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache"
         run: curl -f "$CF_URL" -H "$CF_AUTH" --data '{"purge_everything":true}'
-
-  Release:  # TODO remove, switch to workflow_dispatch
-    if: startsWith(github.ref, 'refs/tags/')  # env.IS_PROD
-    runs-on: ubuntu-latest
-    needs: [Build, Publish]
-    steps:
-      - name: Fetch HTML Files
-        uses: actions/download-artifact@v3
-        with:
-          name: html
-          path: html
-      - name: Archive HTML Files
-        run: tar -czvf html.tar.gz html/
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        env:
-          NAME: "${{ needs.Build.outputs.CL_TITLE }}"
-          BODY: "${{ needs.Build.outputs.CL_DESCRIPTION }}"
-        with:
-          name: "${{ env.NAME }}"
-          body: "${{ env.BODY }}"
-          files: html.tar.gz

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,8 +1,7 @@
 name: Linkcheck
 
 on:
-  pull_request:
-  push: {branches-ignore: ["**_pr"]}
+  push:
 
 jobs:
 


### PR DESCRIPTION
Only staging for now. Deploying to stage during pull requests only. No need to deploy if I just change the README.md file for instance.

DRY: using reusable workflows to keep build logic in build.yml only.

Using GitHub environment within build.yml. Reduces complexity in the caller workflow.

CHANGELOG.md management change: will be updated automatically using commit summaries instead. No longer need to enforce linting, removing all these AWK scripts.

Removing release logic for now.

Deduplicating GHA builds. Every time I make a PR I'm pushing anyway.