### PR TITLE
Refactor linkcheck

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -20,16 +20,11 @@ jobs:
         uses: ./.github/actions/deps
 
       - name: Run linkcheck
-        env:
-          RETRY: 3
-          SLEEP_FOR: 10
         run: |
-          set -ex
-          until make linkcheck; do
-            if (( i++ < RETRY )); then
-              echo Retrying...
-              sleep "$SLEEP_FOR"
-            else
-              exit 1
-            fi
-          done
+          set -eux
+          if ! make linkcheck; do
+            while read -r url; do
+              curl -sSfv -o /dev/null -w "%{http_code}" "$url" > docs/_build/html/status.txt
+              grep '^200$' docs/_build/html/status.txt
+            done < docs/_build/html/broken.txt
+          fi

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run linkcheck
         run: |
           set -eux
-          if ! make linkcheck; do
+          if ! make linkcheck; then
             while read -r url; do
               curl -sSfv -o /dev/null -w "%{http_code}" "$url" > docs/_build/html/status.txt
               grep '^200$' docs/_build/html/status.txt

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ autodocs: docs/_build/html/index.html
 linkcheck: docs/_build/html/index.html
 	poetry run sphinx-build -T -n -W --keep-going -b linkcheck docs $(<D) && ret=0 || ret=$$? && \
 		{ jq -s . $(<D)/output.json > $(<D)/output2.json && mv $(<D)/output2.json $(<D)/output.json; \
-			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/output2.txt; \
+			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/broken.txt; \
 			echo; sort $(<D)/output.txt; exit $$ret; }
 
 ## Misc

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ autodocs: docs/_build/html/index.html
 .PHONY: linkcheck
 linkcheck: docs/_build/html/index.html
 	poetry run sphinx-build -T -n -W --keep-going -b linkcheck docs $(<D) && ret=0 || ret=$$? && \
-		{ echo; sort $(<D)/output.txt; exit $$ret; }
+		{ jq -s . $(<D)/output.json > $(<D)/output2.json && mv $(<D)/output2.json $(<D)/output.json; \
+			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/output2.txt; \
+			echo; sort $(<D)/output.txt; exit $$ret; }
 
 ## Misc
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,10 +112,7 @@ linkcheck_ignore = [
     r"https://[\w.]*mibsolution.one/#",
     r"https://media.vw.com/",  # All curls result in 403
     r"https://mega.nz/(file|folder)/\w+#",
-    r"https://parts.vw.com/",  # Times out frequently
-    r"https://web.archive.org/",  # Intermittent timeouts
     r"https://www.ecstuning.com/",  # All curls result in 403
-    r"https://www.microsoft.com/",  # Times out frequently
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
     r"https?://192.168.\d+.\d+/",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,9 +110,7 @@ linkcheck_exclude_documents = [
 linkcheck_ignore = [
     r"[/.]*genindex.html",  # TODO remove this
     r"https://[\w.]*mibsolution.one/#",
-    r"https://media.vw.com/",  # All curls result in 403
     r"https://mega.nz/(file|folder)/\w+#",
-    r"https://www.ecstuning.com/",  # All curls result in 403
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
     r"https?://192.168.\d+.\d+/",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,9 @@ linkcheck_exclude_documents = [
 linkcheck_ignore = [
     r"[/.]*genindex.html",  # TODO remove this
     r"https://[\w.]*mibsolution.one/#",
+    r"https://media.vw.com/",  # All curls result in 403
     r"https://mega.nz/(file|folder)/\w+#",
+    r"https://www.ecstuning.com/",  # All curls result in 403
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
     r"https?://192.168.\d+.\d+/",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ linkcheck_ignore = [
     r"https://parts.vw.com/",  # Times out frequently
     r"https://web.archive.org/",  # Intermittent timeouts
     r"https://www.ecstuning.com/",  # All curls result in 403
+    r"https://www.microsoft.com/",  # Times out frequently
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
     r"https?://192.168.\d+.\d+/",
 ]


### PR DESCRIPTION
Looks like Sphinx linkcheck fails when curl works fine on some websites. Not gonna spend time investigating since I'll probably soon be ditching Sphinx altogether.

Instead of a simple retry, which doesn't seem to mitigate much these days, instead I'll curl the broken urls and only fail if curl doesn't return http 200. This has fixed the recent microsoft.com timeout issue.