### PR TITLE
Deploy must be push: not PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 
 on:
-  pull_request:
+  push:  # Must be push, not PR, for GITHUB_REF_NAME in website links
 
 
 jobs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from robpol86_com import __license__, __version__ as version
 
-GIT_BRANCH = os.environ.get("SPHINX_GITHUB_BRANCH", "") or os.environ.get("GITHUB_REF", "").split("/", 2)[-1] or None
+GIT_BRANCH = os.environ.get("SPHINX_GITHUB_BRANCH", "") or os.environ.get("GITHUB_REF_NAME", None)
 GIT_URL = f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}' if os.environ.get("GITHUB_REPOSITORY", "") else None
 
 


### PR DESCRIPTION
Otherwise "branch" name is a PR number. I could try to make those links resolve to the right URL but that's additional logic needed in conf.py. May revisit in the future after switching to Hugo, not a priority.