### PR TITLE
Fix linkcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ autodocs: docs/_build/html/index.html
 	poetry run sphinx-autobuild --open-browser --delay=1 --host localhost -n -W docs $(<D)
 
 .PHONY: linkcheck
+linkcheck: _HELP = Check for broken links in documents
 linkcheck: docs/_build/html/index.html
 	poetry run sphinx-build -T -n -W --keep-going -b linkcheck docs $(<D) && ret=0 || ret=$$? && \
 		{ jq -s . $(<D)/output.json > $(<D)/output2.json && mv $(<D)/output2.json $(<D)/output.json; \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ linkcheck: docs/_build/html/index.html
 		{ jq -s . $(<D)/output.json > $(<D)/output2.json && mv $(<D)/output2.json $(<D)/output.json; \
 			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/broken.txt; echo; echo; \
 			echo "======================= output.txt ======================="; sort $(<D)/output.txt; \
-			echo "=========================================================="; exit $$ret; }
+			echo "=========================================================="; echo; echo; exit $$ret; }
 
 ## Misc
 

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,9 @@ linkcheck: _HELP = Check for broken links in documents
 linkcheck: docs/_build/html/index.html
 	poetry run sphinx-build -T -n -W --keep-going -b linkcheck docs $(<D) && ret=0 || ret=$$? && \
 		{ jq -s . $(<D)/output.json > $(<D)/output2.json && mv $(<D)/output2.json $(<D)/output.json; \
-			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/broken.txt; \
-			echo; sort $(<D)/output.txt; exit $$ret; }
+			jq -r '.[] |select(.status == "broken") |.uri' $(<D)/output.json > $(<D)/broken.txt; echo; echo; \
+			echo "======================= output.txt ======================="; sort $(<D)/output.txt; \
+			echo "=========================================================="; exit $$ret; }
 
 ## Misc
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ html_use_index = True
 
 
 # Linkcheck settings.
+user_agent = "Mozilla 5.0"
 linkcheck_allowed_redirects = {
     r"https://www.amazon.com/": "https://www.amazon.com/[^/]+/dp/",
     r"https://www.apc.com/us/en/product/\w+$": "https://www.apc.com/us/en/product/",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ html_use_index = True
 
 
 # Linkcheck settings.
-user_agent = "Mozilla 5.0"
+user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
 linkcheck_allowed_redirects = {
     r"https://www.amazon.com/": "https://www.amazon.com/[^/]+/dp/",
     r"https://www.apc.com/us/en/product/\w+$": "https://www.apc.com/us/en/product/",
@@ -110,10 +110,11 @@ linkcheck_exclude_documents = [
 ]
 linkcheck_ignore = [
     r"[/.]*genindex.html",  # TODO remove this
-    r"https://[\w.]*mibsolution.one/#",
+    r"https://[\w.]*mibsolution.one/",
     r"https://media.vw.com/",  # All curls result in 403
     r"https://mega.nz/(file|folder)/\w+#",
     r"https://parts.vw.com/",  # Nondeterministic rate limiting in GitHub runner
+    r"https://www.apc.com/",
     r"https://www.ecstuning.com/",  # All curls result in 403
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
     r"https?://192.168.\d+.\d+/",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ html_use_index = True
 
 
 # Linkcheck settings.
-user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0"
 linkcheck_allowed_redirects = {
     r"https://www.amazon.com/": "https://www.amazon.com/[^/]+/dp/",
     r"https://www.apc.com/us/en/product/\w+$": "https://www.apc.com/us/en/product/",
@@ -114,9 +114,12 @@ linkcheck_ignore = [
     r"https://media.vw.com/",  # All curls result in 403
     r"https://mega.nz/(file|folder)/\w+#",
     r"https://parts.vw.com/",  # Nondeterministic rate limiting in GitHub runner
+    r"https://torkliftcentral.com/",
     r"https://www.apc.com/",
     r"https://www.ecstuning.com/",  # All curls result in 403
+    r"https://www.howardforums.com/",
     r"https://www.qnx.com/developers/docs/[\w.]+/#",
+    r"https://www.reddit.com/",
     r"https?://192.168.\d+.\d+/",
 ]
 linkcheck_retries = 3

--- a/docs/franklin_t9.md
+++ b/docs/franklin_t9.md
@@ -63,7 +63,7 @@ the issue and still has the hidden pages. Download `R717F21.FR.2000_ota_update_a
 https://mega.nz/folder/FJ8wWYAJ#Q1oUEtIUJrtjB1atkOAXrA
 
 (Got that link from:
-https://www.howardforums.com/showthread.php/1921612-Franklin-T9-Test-Drive-stuck-on-Welcome-This-is-the-fix)
+https://www.howardforums.com/threads/franklin-t9-test-drive-stuck-on-welcome-this-is-the-fix.1921612/)
 
 ## SSH and Root
 

--- a/docs/posts/2022/2022-06-30-server-cabinet.md
+++ b/docs/posts/2022/2022-06-30-server-cabinet.md
@@ -19,7 +19,7 @@ vibration of my spinning hard drives. It's not too bad though.
 * [Hug-A-Plug Grounded Right Angle Adapter (old design)](https://www.hugaplug.com/)
 * [Noctua 5V 120mm Fans](https://noctua.at/en/products/fan/nf-f12-5v)
 * [Cable Matters 24 Port Keystone Patch Panel](https://www.amazon.com/gp/product/B0072JVT02)
-* [NETGEAR XS716T 16-Port 10-Gigabit Ethernet Switch](https://www.netgear.com/support/product/xs716t.aspx)
+* [NETGEAR XS716T 16-Port 10-Gigabit Ethernet Switch](https://www.netgear.com/support/product/xs716t/)
 * [Tripp Lite PDUMH15-6 Metered PDU](https://tripplite.eaton.com/1-4kw-single-phase-metered-pdu-120v~pdumh156)
 * [APC Smart-UPS SMT1500RM2U](https://www.apc.com/us/en/product/SMT1500RM2U)
 * [Travla T2241 2U Dual Mini-ITX Case](http://www.casetronic.com/corporates/49-t2241.html)

--- a/docs/windows_11_mac.md
+++ b/docs/windows_11_mac.md
@@ -121,7 +121,7 @@ Before starting I had to prepare my MacBook and grab a few things:
        yet.
 3. Download and extract [unetbootin](https://unetbootin.github.io/) somewhere on your Mac
     1. Or if you use [Homebrew](https://brew.sh/): `brew install unetbootin`
-4. [Allow booting from a external or removable media](https://support.apple.com/en-us/HT208198)
+4. [Allow booting from a external or removable media](https://support.apple.com/en-us/102522)
 
 You'll also need to obtain the Windows Support Software from the Boot Camp Assistant:
 


### PR DESCRIPTION
Updating links that now redirect.

Added more domains to the ignore list. Kept giving http 403 and 500 in GitHub Actions but not locally, probably an IP filter on their end. APC.com kept HTTP500 locally even though curl with the user agent returned 200. Not looking into it.

Setting the user agent to what my browser currently sends, to fix Amazon links.

Making it easier to human read output.txt from the Makefile. Also adding _HELP for `make linkcheck`, not sure why I omitted it before.