### PR TITLE
Extended version/tag for more releases per day.

### DIFF
--- a/.github/actions/version_bump/action.yml
+++ b/.github/actions/version_bump/action.yml
@@ -16,6 +16,5 @@ runs:
       shell: bash
       env:
         NEW_VERSION: "${{ inputs.new_version }}"
-        PATTERN: '[0-9]\{4\}[.][0-9]\{1,2\}[.][0-9]\{1,2\}'
         VERSION_FILE: pyproject.toml
-      run: sed -i "0,/^version = /s/\"$PATTERN\"/\"$NEW_VERSION\"/" "$VERSION_FILE"
+      run: sed -i "0,/^version = /s/\"[^\"]\+\"/\"$NEW_VERSION\"/" "$VERSION_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0  # for git log
       - name: New Version
         id: new_version
-        run: date $'+NEW_TAG=%Y-%m-%d\nNEW_VERSION=%-Y.%-m.%-d' |tee -a "$GITHUB_OUTPUT"
+        run: date $'+NEW_TAG=%Y-%m-%d-%H%M%S\nNEW_VERSION=%-Y.%-m.%-d.%-H%M%S' |tee -a "$GITHUB_OUTPUT"
       - name: Last Tag
         id: last_tag
         env:
@@ -39,7 +39,7 @@ jobs:
             exit 1
           fi
           git tag |
-            grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' |
+            grep -P '^[0-9]{4}-[0-9]{2}-[0-9]{2}(-[0-9]{6})?$' |
             sort -r |head -1 |
             xargs -I {} echo "LAST_TAG={}"|
             tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
Current versioning and tagging scheme only allows for one release per day, otherwise a tag collision occurs. Adding HMS to the tag and version strings to allow practically unlimited releases per day.