### PR TITLE
Disable Atom feeds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,7 @@ sitemap_url_scheme = "{link}"
 blog_authors = {"Robpol86": ("Robert Pooley", "https://robpol86.com")}
 blog_baseurl = html_baseurl
 blog_default_language = language
-blog_feed_archives = True
+blog_feed_archives = False
 blog_languages = {"en": ("English", None)}
 blog_locations = {
     "Austin": ("Austin, TX", "https://en.wikipedia.org/wiki/Austin,_Texas"),


### PR DESCRIPTION
Enabled this just because it was available in #267 but turning it off now. XML files have an updated field with the current time of generation. Not based on mtime of any file, running `make clean docs` confirms the current date is set. This causes my diff feature in PRs to be nearly useless.