### PR TITLE
Making docs version static for Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,6 @@ import os
 import time
 from urllib.parse import urlparse
 
-from robpol86_com import __version__ as version
-
 GIT_BRANCH = os.environ.get("SPHINX_GITHUB_BRANCH", "") or os.environ.get("GITHUB_REF_NAME", None)
 GIT_URL = f'https://github.com/{os.environ["GITHUB_REPOSITORY"]}' if os.environ.get("GITHUB_REPOSITORY", "") else None
 
@@ -29,6 +27,7 @@ extensions = [
 language = "en"
 project = "Robpol86.com"
 pygments_style = "vs"
+version = "1.0.0"
 release = version
 templates_path = ["_templates"]
 


### PR DESCRIPTION
Main driver for this change is to reduce noise in HTML diffs in pull requests. Keeping the version static in the documentation produces deterministic output files.

This wasn't a problem before I upgraded Sphinx and other libraries to the latest version, which now inject the docs version in documentation_options.js This changes the hash which is now hard-coded into HTML files. So every PR causes changes to ALL HTML files.