### PR TITLE
Fixing syntax highlighting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "analytics": {"google_analytics_id": "G-EJSD449CRH"},
     "path_to_docs": "docs",
-    "pygment_light_style": f"{pygments_style}",
+    "pygment_light_style": pygments_style,
     "repository_branch": GIT_BRANCH,
     "repository_url": GIT_URL,
     "use_download_button": False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "analytics": {"google_analytics_id": "G-EJSD449CRH"},
     "path_to_docs": "docs",
+    "pygment_light_style": f"{pygments_style}",
     "repository_branch": GIT_BRANCH,
     "repository_url": GIT_URL,
     "use_download_button": False,


### PR DESCRIPTION
Looks like the Sphinx Book Theme has been overriding the pygments_style option in conf.py for a while.

According to
https://github.com/executablebooks/sphinx-book-theme/issues/762 the value is ingested through `html_theme_options`.

Fixes https://github.com/Robpol86/robpol86.com/issues/281