### PR TITLE
Rephrased again.

### DIFF
--- a/docs/posts/2025/2025-07-23-truenas-scale-telegraf.md
+++ b/docs/posts/2025/2025-07-23-truenas-scale-telegraf.md
@@ -16,16 +16,16 @@ tags: homelab, nas
   - :::{imgur} AzEomCa.png
 ```
 
-[Telegraf](https://www.influxdata.com/time-series-platform/telegraf/), [InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/),
-and [Grafana](https://grafana.com/oss/grafana/) are separate pieces of software that together allow you to graph metrics from
+This guide will explain how to setup [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/),
+[InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/), and [Grafana](https://grafana.com/oss/grafana/) on
+[TrueNAS SCALE (Community Edition)](https://www.truenas.com/truenas-community-edition/). This is how I run all three apps on
+my [Beelink ME Mini](https://www.bee-link.com/products/beelink-me-mini-n150) NAS. As of this writing I'm running TrueNAS
+SCALE 25.04.1 (Fangtooth). The scope of this guide is to implement homelab-tier monitoring on a single node.
+
+Telegraf, InfluxDB, and Grafana are separate pieces of software that together allow you to graph metrics from
 your servers and devices. With these graphs, charts, and other visualization tools available in Grafana, you can see
 historical trends of space usage, CPU usage, and almost anything else. The three components make up the "TIG Stack", where
 Telegraf collects the data, InfluxDB stores the data in a kind of database, and Grafana produces the graphs and alerts.
-
-This guide will explain how to setup the TIG Stack on your NAS running
-[TrueNAS Community Edition (SCALE)](https://www.truenas.com/truenas-community-edition/). This is how I run all three apps on
-my [Beelink ME Mini](https://www.bee-link.com/products/beelink-me-mini-n150) NAS. As of this writing I'm running TrueNAS
-SCALE 25.04.1 (Fangtooth). The scope of this guide is to implement homelab-tier monitoring on a single node.
 
 Ever since I saw [MRTG](https://en.wikipedia.org/wiki/Multi_Router_Traffic_Grapher) graphs at my first job at an ISP in 2003,
 I've always wanted to collect metrics and visualize them in graphs. Things like free disk space or CPU temperatures. I ran


### PR DESCRIPTION
When accessing the TrueNAS Telegraf page via city/category listing pages (thanks to Google not showing the direct page in search resuls anymore) the synopsis should be straight to the point. Only the first paragraph of the page is shown there.