### PR TITLE
Fix alert, new output name

### DIFF
--- a/docs/_static/telegraf.conf
+++ b/docs/_static/telegraf.conf
@@ -14,7 +14,7 @@
 [[outputs.health]]
   service_address = "http://:12121"
   namepass = ["internal_write"]
-  tagpass = { output = ["influxdb"] }
+  tagpass = { output = ["influxdb_v2"] }
   [[outputs.health.compares]]
     field = "buffer_size"
     lt = 2000.0


### PR DESCRIPTION
Forgot to update this during the InfluxDB v2 migration.