### PR TITLE
Fix derivative found out-of-order times in time column

### DIFF
--- a/docs/_static/grafana.json
+++ b/docs/_static/grafana.json
@@ -1864,7 +1864,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"diskio\")\n  |> filter(fn: (r) => r.DEVTYPE == \"disk\")\n  |> filter(fn: (r) => r._field == \"read_bytes\" or r._field == \"write_bytes\")\n  |> drop(columns: [\"name\", \"DEVLINKS\"])\n  |> derivative(unit: 1s, nonNegative: true)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"diskio\")\n  |> filter(fn: (r) => r.DEVTYPE == \"disk\")\n  |> filter(fn: (r) => r._field == \"read_bytes\" or r._field == \"write_bytes\")\n  |> derivative(unit: 1s, nonNegative: true)\n  |> drop(columns: [\"name\", \"DEVLINKS\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -2184,6 +2184,6 @@
   "timezone": "browser",
   "title": "NAS",
   "uid": "f1639b8d-85ff-4a51-bc8c-47567de87b46",
-  "version": 22,
+  "version": 23,
   "weekStart": ""
 }


### PR DESCRIPTION
Disk IO panel broken after reboot. Dropping "name" because nvme0n1 and so on are not guaranteed to be the same across reboots on the same machine, but this seems to break derivative. Moving the drop() below derivative() seems to fix the issue.