### PR TITLE
Remove imgur extension.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@ extensions = [
     "myst_parser",  # https://myst-parser.readthedocs.io
     "notfound.extension",  # https://sphinx-notfound-page.readthedocs.io
     "sphinx_copybutton",  # https://sphinx-copybutton.readthedocs.io
-    "sphinx_imgur.imgur",  # https://sphinx-imgur.readthedocs.io
     "sphinx_sitemap",  # https://sphinx-sitemap.readthedocs.io
     "sphinx_thumb_image",  # https://sphinx-thumb-image.readthedocs.io
     "sphinxcontrib.youtube",  # https://sphinxcontrib-youtube.readthedocs.io
@@ -122,7 +121,6 @@ linkcheck_timeout = 5
 
 
 # Extension settings.
-imgur_target_format = "https://i.imgur.com/%(id)s.%(ext)s"
 myst_enable_extensions = ["colon_fence", "deflist", "fieldlist", "linkify", "replacements", "strikethrough", "substitution"]
 myst_heading_anchors = 3
 myst_url_schemes = ("http", "https", "mailto")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1666,24 +1666,6 @@ code-style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
-name = "sphinx-imgur"
-version = "3.0.0"
-description = "Embed Imgur images and albums in Sphinx documents/pages."
-optional = false
-python-versions = ">=3.6.2,<4.0.0"
-groups = ["main"]
-files = [
-    {file = "sphinx-imgur-3.0.0.tar.gz", hash = "sha256:db5dbd1169f60468394ebfb9b3f1387a4f4ed567b061c98ad1312048afe5a760"},
-    {file = "sphinx_imgur-3.0.0-py3-none-any.whl", hash = "sha256:6048f2a6a00192124849d679ca3ac7c29eaad6150e4a51a238ba9337f42d772e"},
-]
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-docs = ["sphinx-copybutton", "sphinx-notfound-page", "sphinx-panels", "sphinx-rtd-theme", "sphinxext-opengraph", "toml"]
-
-[[package]]
 name = "sphinx-last-updated-by-git"
 version = "0.3.8"
 description = "Get the \"last updated\" time for each Sphinx page from Git"
@@ -2225,4 +2207,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14"
-content-hash = "802df60ab383e51c5b60acb3134f506297df512272553f0ec78a625753337e81"
+content-hash = "586302a4200052097e1cacfe33831860d26d0c763a1d0a7494f222a3c41a5640"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "sphinx",
     "sphinx-book-theme",
     "sphinx-copybutton",
-    "sphinx-imgur",
     "sphinx-notfound-page",
     "sphinx-sitemap",
     "sphinx-thumb-image",


### PR DESCRIPTION
Migrated to sphinx-thumb-image. No longer need Imgur.

Fixes https://github.com/Robpol86/robpol86.com/issues/312