### PR TITLE
Switch from pkg_resources to importlib

### DIFF
--- a/robpol86_com/__init__.py
+++ b/robpol86_com/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = "Robpol86"
 __license__ = "BSD-2-Clause"
-__version__ = __import__("pkg_resources").get_distribution(__name__).version
+__version__ = __import__("importlib").metadata.version(__name__)


### PR DESCRIPTION
Fixes deprecation warning for now. May need to revisit in the future when this gets deprecated.

Fixes https://github.com/Robpol86/robpol86.com/issues/325