### PR TITLE
Change aggregate function from max() to mean()

### DIFF
--- a/docs/_static/grafana.json
+++ b/docs/_static/grafana.json
@@ -254,7 +254,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Temperature_Celsius\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Temperature_Celsius\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -358,7 +358,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name =~ /(Temperature_Sensor_|Airflow_Temperature)/)\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name =~ /(Temperature_Sensor_|Airflow_Temperature)/)\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -460,7 +460,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"sensors\")\n  |> filter(fn: (r) => r._field == \"temp_input\")\n  |> filter(fn: (r) => r.feature =~ /core_/)\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"sensors\")\n  |> filter(fn: (r) => r._field == \"temp_input\")\n  |> filter(fn: (r) => r.feature =~ /core_/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -564,7 +564,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"sensors\")\n  |> filter(fn: (r) => r._field == \"temp_input\")\n  |> filter(fn: (r) => r.feature =~ /package|temp/)\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"sensors\")\n  |> filter(fn: (r) => r._field == \"temp_input\")\n  |> filter(fn: (r) => r.feature =~ /package|temp/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -1026,7 +1026,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Unsafe_Shutdowns\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Unsafe_Shutdowns\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -1127,7 +1127,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Available_Spare\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Available_Spare\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -1268,7 +1268,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Percentage_Used\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name == \"Percentage_Used\")\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",
@@ -1409,7 +1409,7 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name =~ /Temperature_Time/)\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "query": "from(bucket: \"${BUCKET}\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r.host == \"${NAS_HOST}\")\n  |> filter(fn: (r) => r._measurement == \"smart_attribute\")\n  |> filter(fn: (r) => r._field == \"raw_value\")\n  |> filter(fn: (r) => r.name =~ /Temperature_Time/)\n  |> drop(columns: [\"device\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
           "refId": "A",
           "datasource": {
             "type": "influxdb",


### PR DESCRIPTION
When used with downsampling if the user zooms out in Grafana to see downsampling in action, the raw 10second data will be much higher than the rest of the graph. This is because downsampling uses mean(), but Grafana was using max().

Changing it to mean() makes everythign the same and with no more false reporting of elevated temperatures.