### PR TITLE
Bump robpol86_com package version in lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,16 @@ jobs:
         uses: ./.github/actions/version_bump
         with:
           new_version: "${{ steps.new_version.outputs.NEW_VERSION }}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Update robpol86_com in lockfile
+        run: uv sync --package robpol86_com
       - name: Commit and Push
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "${{ steps.new_version.outputs.NEW_VERSION }}: ${{ inputs.release_title }}"
-          file_pattern: CHANGELOG.md pyproject.toml
+          file_pattern: CHANGELOG.md pyproject.toml uv.lock
     outputs:
       GIT_LOG: "${{ steps.git_log.outputs.GIT_LOG }}"
       NEW_COMMIT: "${{ steps.commit.outputs.commit_hash }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@ Notes for project maintainers.
 1. **Canonical Name**: rob86stage.robpol86.com
 1. **Setup DNS?**: No
 1. **Server Type**: Apache 2.4 Static Content
+1. Create
+1. Site Information > **HTTPS Redirection**: Off
+1. Wait 10 minutes for Cloudflare to catch up
 
 No further action needed. SSH keys are already pre-configured.
 

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "robpol86-com"
-version = "2026.2.17.62618"
+version = "2026.3.3.64345"
 source = { editable = "." }
 dependencies = [
     { name = "ablog" },


### PR DESCRIPTION
After each release, the project's version in pyproject.toml is updated. This causes uv to report the lockfile as stale since the previous version persists in the lockfile.

Include bumping the project version also in the lockfile upon release.

Also update documentation on NFSN changes to defaults of new sites for creating staging.

Fixes https://github.com/Robpol86/robpol86.com/issues/365